### PR TITLE
Fix missing TS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,11 +6,22 @@ const rules = {};
 
 // Requires and sets the rules of the eslint-plugins used by create-react-app.
 plugins.forEach(plugin => {
-  const pluginModule = require(plugin.name);
-  Object.keys(pluginModule.rules).forEach(ruleName => {
-    rules[`${plugin.rulePrefix}/${ruleName}`] = pluginModule.rules[ruleName];
-  });
-});
+  try {
+    const pluginModule = require(plugin.name)
+    Object.keys(pluginModule.rules).forEach(ruleName => {
+      rules[`${plugin.rulePrefix}/${ruleName}`] = pluginModule.rules[ruleName]
+    })
+  } catch (err) {
+    // If the user doesn't have typescript installed skip the @typescript-eslint
+    // rules setup. The other JS rules will still work correctly.
+    const isTypescriptMissing =
+      err.message === `Cannot find module 'typescript'` &&
+      plugin.rulePrefix === "@typescript-eslint"
+    if (!isTypescriptMissing) {
+      throw err
+    }
+  }
+})
 
 module.exports = {
   configs: {


### PR DESCRIPTION
If the user doesn't have typescript installed skip the `@typescript-eslint` rules setup.  
The other JS rules will still work correctly.