### PR TITLE
Update eslint-plugin-react-hooks to 4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-hooks": "1.x || 2.x"
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "peerDependencies": {
     "eslint": "6.x"


### PR DESCRIPTION
Thank you for publishing a good package.

This package is currently using `eslint-plugin-react-hooks` 2.x version with [this issue](https://github.com/facebook/react/issues/18985)

So, I updated `eslint-plugin-react-hooks` package to version 4.2.0.

Thank you.